### PR TITLE
config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ONBUILD WORKDIR /aem
 ONBUILD RUN java -XX:MaxPermSize=256m -Xmx1024M -jar cq-author-4502.jar -unpack -r nosamplecontent
 
 # Add customised log file, to print the logging to standard out.
-ONBUILD ADD https://raw.githubusercontent.com/ggotti/aem-author/master/org.apache.sling.commons.log.LogManager.config /aem/crx-quickstart/install
+ONBUILD ADD https://raw.githubusercontent.com/ggotti/aem-author/master/org.apache.sling.commons.log.LogManager.config /aem/crx-quickstart/install/
 
 # Installs AEM
 ONBUILD RUN ["python","aemInstaller.py","-i","cq-author-4502.jar","-r","author","-p","4502"]


### PR DESCRIPTION
The LogManager.config is being copied and renamed to install as a file not a directory as intended.
To create an install directory you will need to add the / after it.  
When there is no / (slash) you will copy and rename the file. 
ADD aem-publisher-4503.jar /aem/cq-author-4502.jar
